### PR TITLE
pin and bump 3rd-party actions in the release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,14 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    cooldown:
+      default-days: 15
+    groups:
+      gha-dependencies:
+        patterns:
+          - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Create release
         if: steps.version.outputs.valid
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           name: Cross Platform Action ${{ steps.version.outputs.version }}
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - name: Extract changelog
-        uses: sean0x42/markdown-extract@v2
+        uses: sean0x42/markdown-extract@7b185cbe85263116bbf741e739e7198ba86465dc  # v2.1.0
         id: extract_changelog
         with:
          file: changelog.md


### PR DESCRIPTION
- pin sean0x42/markdown-extract to hash.
- pin softprops/action-gh-release to hash and bump to latest.
- dependabot: enable for github-actions, monthly, grouped, with cooldown 
  period.

---

Bumping softprops/action-gh-release to latest is not critical, but I
could not figure out which version `v1` is mapping to at the moment. The 
v2 series started using node20, and node24 with v2.3.0, which probably
speaks for bumping at least to that one.

Ref: https://github.com/softprops/action-gh-release/releases

I updated dependabot.yml; also entirely optional, and/or may be changed
for more or less frequent action. We use about this config in curl,
balancing between staying fresh and Dependabot interruptions.
